### PR TITLE
Fix file upload parameter validation

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -168,6 +168,7 @@ server.registerTool("slack_upload_file",
                    mimeType: z.string().optional() } },
   async ({ channels, filename, title, initial_comment, content, data_base64, mimeType }) => {
     if (!content && !data_base64) throw new Error("Provide either 'content' or 'data_base64'.");
+    if (content && data_base64) throw new Error("Provide either 'content' or 'data_base64', not both.");
     if (content) {
       // Simple path: send as 'content' (Slack treats it as text)
       const form = new FormData();


### PR DESCRIPTION
## Summary
- ensure `slack_upload_file` rejects simultaneous `content` and `data_base64` inputs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4d2b507ac832d9c10e6463f440fd4